### PR TITLE
Update getting-started.html

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -59,7 +59,7 @@
 <p>In order to write a nickel app you first need to make sure to have a recent version of Rust and <a href="http://crates.io/">Cargo</a>. In case you are wondering Cargo is the package manager for Rust. It makes dependency and build management a breeze. The easiest way to install both is just a simple one liner on your shell.</p>
 
 
-<pre><code>$ curl -s http://www.rust-lang.org/rustup.sh | sudo sh
+<pre><code>$ curl -s https://static.rust-lang.org/rustup.sh | sudo sh
 </code></pre>
 
 <h3>


### PR DESCRIPTION
Per warning when I used the original url: Downloading rustup.sh from http://www.rust-lang.org/rustup.sh is deprecated. Use https://static.rust-lang.org/rustup.sh instead.
