### PR TITLE
Fixed typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@ fn main() {
 <a name="error-handling" class="anchor" href="#error-handling"><span class="octicon octicon-link"></span>Custom error handler</a></h3>
 
 <p>
-  By default nickel catches all errors with it's default <code>ErrorHandler</code> and tries to take reasonable actions. In cases where one wants to provide an own <code>ErrorHandler</code> (e.g. for custom 404 pages), it's trivial to write one.
+  By default nickel catches all errors with its default <code>ErrorHandler</code> and tries to take reasonable actions. In cases where one wants to provide an own <code>ErrorHandler</code> (e.g. for custom 404 pages), it's trivial to write one.
 </p>
 
 <pre><code class="rust">extern crate http;


### PR DESCRIPTION
Contracted verb form "it's" was used instead of possessive pronoun "its"
