### PR TITLE
Eliminate a compilation warning on an unreachable expression in templating example

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@ fn main() {
     server.get("/", middleware! { |_, response|
         let mut data = HashMap::new();
         data.insert("name", "user");
-        return response.render("examples/assets/template.tpl", &data);
+        return response.render("examples/assets/template.tpl", &data)
     });
 
     server.listen("127.0.0.1:6767");


### PR DESCRIPTION
  <nickel macros>:10:37: 10:38 warning: unreachable expression, #[warn(unreachable_code)] on by default
  <nickel macros>:10 _middleware_inner ! ( $ req , $ res , $ res , $ ( $ b ) + ) } ; (
                                                         ^
  <nickel macros>:10:1: 10:60 note: in this expansion of _middleware_inner! (defined in <nickel macros>)
  src/main.rs:9:21: 13:6 note: in this expansion of middleware! (defined in <nickel macros>)
